### PR TITLE
allocate-ports: avoid failure on domain removal

### DIFF
--- a/imageroot/bin/allocate-ports
+++ b/imageroot/bin/allocate-ports
@@ -75,7 +75,8 @@ rdb.close() # close the read-only connection
 if len(user_domain_changed_events) > 0:
     with agent.redis_connect(privileged=True).pipeline() as trx:
         trx.delete(f'{agent_id}/data/domain_port')
-        trx.hset(f'{agent_id}/data/domain_port', mapping=domain_port)
+        if domain_port:
+            trx.hset(f'{agent_id}/data/domain_port', mapping=domain_port)
         for domevent in user_domain_changed_events:
             trx.publish(f'{agent_id}/event/user-domain-changed', json.dumps(domevent))
         trx.execute()


### PR DESCRIPTION
When remove-external-domain is invoked on a AD domain, like during NS7 migration, the command was failing with an errore lkie:

 File "/usr/local/agent/pyenv/lib64/python3.9/site-packages/redis/client.py", line 3042, in hset
      raise DataError("'hset' with no key value pairs")