### PR TITLE
Avoid bind IPv6 failure

### DIFF
--- a/imageroot/templates/nginx.conf.j2
+++ b/imageroot/templates/nginx.conf.j2
@@ -14,7 +14,6 @@ stream {
     # Domain {{ item.domain }}
     server {
         proxy_pass {{ item.domain | replace('.', '_') }};
-        listen [::1]:{{ item.listen_port }};
         listen 127.0.0.1:{{ item.listen_port }};
 
         proxy_ssl {{ 'on' if item.tls == '1' else 'off' }};


### PR DESCRIPTION
If the host does not provide IPv6 loopback address the stream configuration fails. In the module log:

    [emerg] 1#1: bind() to [::1]:20001 failed (99: Address not available)

As only 127.0.0.1 is actually required, remove the IPv6 bind completely.

See https://trello.com/c/DbgaOO4F/443-core-p0-ldapproxy-ipv6-bind-error