### PR TITLE
Fix nginx.conf with TLS verification

### DIFF
--- a/imageroot/templates/nginx.conf.j2
+++ b/imageroot/templates/nginx.conf.j2
@@ -17,11 +17,15 @@ stream {
         listen 127.0.0.1:{{ item.listen_port }};
 
         proxy_ssl {{ 'on' if item.tls == '1' else 'off' }};
-        proxy_ssl_verify {{ 'on' if item.tls_verify == '1' else 'off' }};
+        {%- if item.tls_verify == '1' %}
+        proxy_ssl_verify on;
         proxy_ssl_verify_depth {{ item.tls_verify_depth | default('2') }};
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+        proxy_ssl_name {{ (item.servers|first).host }};
+        {%- endif %}
     }
     upstream {{ item.domain | replace('.', '_') }} {
-    {%- for server in item.servers %}
+    {%- for server in ([item.servers[0]] if item.tls_verify == '1' else item.servers) %}
         server {{ server.host + ':' + server.port + ('    backup' if not server.is_local and not loop.index0 == 0 else '') }}; # origin {{ server.origin }}
     {%- endfor %}
     }


### PR DESCRIPTION
When tls_verify is "on", our Nginx configuration seems limited to one backend server only, because the proxy_ssl_name value must match the TLS certificate name.

Furthermore we must add the ca-certificates bundle provided by the container image (based on Alpine Linux), for the upstream certificate chain verification.

This PR changes only the backend configuration. We ought to modify the UI accordingly.

Refs NethServer/dev#6859
Closes #12 