### PR TITLE
Fix definition of primary/backup backend attribute

### DIFF
--- a/imageroot/bin/expand-template
+++ b/imageroot/bin/expand-template
@@ -80,7 +80,7 @@ for domain in domains:
             'origin': domain,
              'service': 'ldap',
              'node': provider['node'],
-             'is_local': node_id == provider['node'],
+             'is_local': str(node_id) == str(provider['node']),
              'port': str(provider['port']),
              'host': provider['host'] if node_id != provider['node'] else '127.0.0.1',
         }


### PR DESCRIPTION
The comparison fails to distinguish between local and remote servers because the type returned by the library is integer whilst the environment variable NODE_ID is a string.

NethServer/dev#6905