### PR TITLE
Add module-removed event handler script

### DIFF
--- a/imageroot/events/module-removed/10handler
+++ b/imageroot/events/module-removed/10handler
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2026 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# The module-removed event is raised when a module is removed from the
+# cluster. When the removed module was an LDAP provider, ldapproxy must
+# reconfigure itself to drop the stale upstream server entry.
+
+set -e
+
+systemctl --user try-reload-or-restart ldapproxy


### PR DESCRIPTION
Implement a script to handle the module-removed event, ensuring ldapproxy reconfigures itself when an LDAP provider module is removed from the cluster.

https://github.com/NethServer/dev/issues/7841